### PR TITLE
Fix kublin_nor() for multi-element Dx; add Python calculator port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 .RData
 .Ruserdata
 inst/doc
+
+# Python
+python/**/__pycache__/
+python/**/*.egg-info/
+python/.pytest_cache/
+python/build/
+python/dist/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,5 +12,8 @@ LazyData: true
 Imports:
     TapeR
 RoxygenNote: 7.3.2
-Depends: 
+Depends:
     R (>= 2.10)
+Suggests:
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/R/kublin_no.R
+++ b/R/kublin_no.R
@@ -13,6 +13,9 @@
 #' @param sp species
 #' @param ... parameters handed over to E_DHx_HmDm_HT.f or E_HDx_HmDm_HT.f
 #' @return When Hx is given: diameters at Hx (cm). When Dx is given: heights where d=Dx (m).
+#'   \code{TapeR::E_HDx_HmDm_HT.f()} only root-finds a single height per call, so when
+#'   \code{Dx} has length > 1 it is called once per element of \code{Dx} and the
+#'   resulting heights are combined into a vector of the same length as \code{Dx}.
 #' @export
 
 kublin_nor <- function(Hx=NULL,Hm,Dm,mHt,sp=1,Dx=NULL,...) {
@@ -25,7 +28,13 @@ kublin_nor <- function(Hx=NULL,Hm,Dm,mHt,sp=1,Dx=NULL,...) {
     par_lme<-kublin_par_lme_spruce
   }
   if(is.null(Hx)&!is.null(Dx)){
-    TapeR::E_HDx_HmDm_HT.f(Dx = Dx,Hm = Hm,Dm = Dm,mHt,par.lme = par_lme,...)
+    if(length(Dx)>1){
+      vapply(Dx, function(Dx_i){
+        TapeR::E_HDx_HmDm_HT.f(Dx = Dx_i,Hm = Hm,Dm = Dm,mHt,par.lme = par_lme,...)
+      }, FUN.VALUE = numeric(1))
+    } else {
+      TapeR::E_HDx_HmDm_HT.f(Dx = Dx,Hm = Hm,Dm = Dm,mHt,par.lme = par_lme,...)
+    }
   } else if ((!is.null(Hx))&is.null(Dx)){
     TapeR::E_DHx_HmDm_HT.f(Hx = Hx,Hm = Hm,Dm = Dm,mHt,par.lme = par_lme,...)
   } else {

--- a/man/kublin_nor.Rd
+++ b/man/kublin_nor.Rd
@@ -23,6 +23,9 @@ kublin_nor(Hx = NULL, Hm, Dm, mHt, sp = 1, Dx = NULL, ...)
 }
 \value{
 When Hx is given: diameters at Hx (cm). When Dx is given: heights where d=Dx (m).
+\code{TapeR::E_HDx_HmDm_HT.f()} only root-finds a single height per call, so when
+\code{Dx} has length > 1 it is called once per element of \code{Dx} and the
+resulting heights are combined into a vector of the same length as \code{Dx}.
 }
 \description{
 Based on Kublin et al. 2013. A flexible stem taper and volume prediction method based on mixed-effects B-spline regression. Eur J For Res. 132(5-6):983–997

--- a/python/README.md
+++ b/python/README.md
@@ -39,3 +39,20 @@ dlocation(dbh=30, h_top=25, d=[25, 15], sp="spruce")
 
 `sp` accepts the same aliases as the R package: `"spruce"`/`"s"`/`"gran"`/`"g"`/`"1"`,
 `"pine"`/`"p"`/`"furu"`/`"f"`/`"2"`, and `"birch"`/`"b"`/`"bjørk"`/`"bjork"`/`"bj"`/`"lauv"`/`"l"`/`"3"`.
+
+## Differences from the R package
+
+- `taper_nor()`, `bark_nor()`, `volume()`, and `hfromd()` return unrounded
+  floats, matching R's behavior (`dlocation()` rounds to 2 decimals, also
+  matching R).
+- `volume()`'s `sp` and `with_bark` accept either a single value (applied to
+  every tree) or one value per tree, like R.
+- If `h_vol_lower > h_vol_upper` for a tree, `h_vol_lower` is clamped to
+  `h_vol_upper` for that tree (volume 0). R has an inverted-condition bug in
+  this edge case that instead zeroes out the *valid* trees; this port does
+  not replicate that bug.
+- `hfromd()` always runs the 12x8 grid search of starting points (R's
+  `grd_search=TRUE` mode) rather than R's default single-optimization
+  attempt, and always returns both `h_top` and `dbh` (R's `output=`
+  parameter is not exposed). Because R's `optim()` and SciPy's optimizers
+  differ internally, results are close but not bit-identical to R.

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,41 @@
+# taper-nor
+
+Python port of the taper, bark, volume, and inverse-taper "calculator"
+functions from the [taperNOR](https://github.com/SmartForest-no/taperNOR) R
+package, for spruce, pine, and birch in Norway.
+
+This package does **not** include `kublin_nor()`, which depends on the
+`TapeR` mixed-effects model and remains R-only (use the R package, e.g. via
+`Rscript`, for that function).
+
+## Installation
+
+```bash
+pip install "git+https://github.com/SmartForest-no/taperNOR.git#subdirectory=python"
+```
+
+## Usage
+
+```python
+from taper_nor import taper_nor, bark_nor, volume, hfromd, dlocation
+
+# Diameter (cm) at 1 m above ground for a spruce, dbh=30 cm, total height=25 m
+taper_nor(h=1, dbh=30, h_top=25, sp="spruce")
+
+# Bark thickness (mm)
+bark_nor(d=25, h=1, dbh=30, h_top=25, sp="spruce")
+
+# Stem volume (m^3)
+volume(dbh=[30], h_top=[25], sp="spruce")
+
+# Estimate total height and dbh from diameter measurements
+hfromd(d=[39, 27], h=[2, 7], sp="birch")
+
+# Height(s) along the stem at which given diameters occur
+dlocation(dbh=30, h_top=25, d=[25, 15], sp="spruce")
+```
+
+## Species
+
+`sp` accepts the same aliases as the R package: `"spruce"`/`"s"`/`"gran"`/`"g"`/`"1"`,
+`"pine"`/`"p"`/`"furu"`/`"f"`/`"2"`, and `"birch"`/`"b"`/`"bjørk"`/`"bjork"`/`"bj"`/`"lauv"`/`"l"`/`"3"`.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "taper-nor"
+version = "0.1.0"
+description = "Taper, bark, volume, and inverse taper models for spruce, pine, and birch in Norway"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [
+    { name = "Johannes Rahlf" },
+    { name = "Endre Hofstad Hansen" },
+]
+dependencies = [
+    "numpy",
+    "scipy",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.setuptools.packages.find]
+include = ["taper_nor*"]

--- a/python/taper_nor/__init__.py
+++ b/python/taper_nor/__init__.py
@@ -1,0 +1,22 @@
+"""Taper, bark, volume, and inverse-taper models for spruce, pine, and birch in Norway.
+
+Python port of the "calculator" functions in the taperNOR R package
+(https://github.com/SmartForest-no/taperNOR). ``kublin_nor()`` is not
+included here, as it depends on the TapeR mixed-effects model and remains
+R-only.
+"""
+
+from .bark import bark_nor
+from .coefficients import normalize_species
+from .inverse import dlocation, hfromd
+from .taper import taper_nor
+from .volume import volume
+
+__all__ = [
+    "taper_nor",
+    "bark_nor",
+    "volume",
+    "hfromd",
+    "dlocation",
+    "normalize_species",
+]

--- a/python/taper_nor/bark.py
+++ b/python/taper_nor/bark.py
@@ -1,0 +1,45 @@
+"""Bark thickness model for spruce, pine, and birch in Norway."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+from .coefficients import BARK_COEFFICIENTS, normalize_species
+
+
+def _bark(
+    d: npt.ArrayLike, h: npt.ArrayLike, dbh: float, h_top: float, sp: str
+) -> np.ndarray:
+    """Bark thickness (mm) for a normalized species key."""
+    c = BARK_COEFFICIENTS[sp]
+    d = np.asarray(d, dtype=float)
+    return c["b0"] + c["b1"] * dbh + c["b2"] * d
+
+
+def bark_nor(
+    d: Sequence[float] | npt.ArrayLike,
+    h: Sequence[float] | npt.ArrayLike,
+    dbh: float,
+    h_top: float,
+    sp: str = "spruce",
+) -> list[float]:
+    """Bark thickness (mm) at given diameter/height pairs.
+
+    Based on Hannrup (2004), via Stängle et al. (2017).
+
+    Args:
+        d: Diameter(s) over bark (cm) at the corresponding height(s) in ``h``.
+        h: Height(s) above ground (m) corresponding to ``d``.
+        dbh: Diameter at breast height, 1.3 m above ground, over bark (cm).
+        h_top: Total tree height (m).
+        sp: Species, see :func:`taper_nor.coefficients.normalize_species`.
+
+    Returns:
+        Bark thickness (mm) for each element of ``d``.
+    """
+    sp_n = normalize_species(sp)
+    result = _bark(d, h, dbh, h_top, sp_n)
+    return [round(float(x), 4) for x in np.atleast_1d(result)]

--- a/python/taper_nor/bark.py
+++ b/python/taper_nor/bark.py
@@ -38,8 +38,9 @@ def bark_nor(
         sp: Species, see :func:`taper_nor.coefficients.normalize_species`.
 
     Returns:
-        Bark thickness (mm) for each element of ``d``.
+        Bark thickness (mm) for each element of ``d``. Unrounded, matching
+        R's ``barkNOR()``.
     """
     sp_n = normalize_species(sp)
     result = _bark(d, h, dbh, h_top, sp_n)
-    return [round(float(x), 4) for x in np.atleast_1d(result)]
+    return [float(x) for x in np.atleast_1d(result)]

--- a/python/taper_nor/coefficients.py
+++ b/python/taper_nor/coefficients.py
@@ -1,0 +1,86 @@
+"""Species coefficients and species-name normalization.
+
+Coefficients are taken from Hansen et al. (2023) (taper, exponent terms) and
+Hannrup (2004), via Stängle et al. (2017) (bark thickness).
+"""
+
+from __future__ import annotations
+
+TAPER_COEFFICIENTS: dict[str, dict[str, float]] = {
+    "spruce": dict(
+        b1=1.0625010,
+        b2=0.9590684,
+        b3=0.9982461,
+        b4=2.2909135,
+        b5=-0.5201230,
+        b6=3.8808849,
+        b7=-2.1078922,
+        b8=0.1695809,
+    ),
+    "pine": dict(
+        b1=1.14798036,
+        b2=0.90295964,
+        b3=1.00118665,
+        b4=0.24116857,
+        b5=-0.09667025,
+        b6=-0.50359177,
+        b7=0.32132441,
+        b8=0.05546691,
+    ),
+    "birch": dict(
+        b1=0.9810885,
+        b2=0.9936293,
+        b3=0.9941538,
+        b4=0.8526987,
+        b5=-0.1819791,
+        b6=0.4687623,
+        b7=-0.2198294,
+        b8=0.1591102,
+    ),
+}
+
+BARK_COEFFICIENTS: dict[str, dict[str, float]] = {
+    "spruce": dict(b0=2.32391608, b1=0.06830421, b2=0.39936183),
+    "pine": dict(b0=2.9306985, b1=-0.4045155, b2=1.2126856),
+    "birch": dict(b0=-0.48552367, b1=0.04957885, b2=0.84676248),
+}
+
+_SPECIES_ALIASES: dict[str, str] = {
+    "spruce": "spruce",
+    "s": "spruce",
+    "gran": "spruce",
+    "g": "spruce",
+    "1": "spruce",
+    "pine": "pine",
+    "p": "pine",
+    "furu": "pine",
+    "f": "pine",
+    "2": "pine",
+    "birch": "birch",
+    "b": "birch",
+    "bjørk": "birch",
+    "bjork": "birch",
+    "bj": "birch",
+    "lauv": "birch",
+    "l": "birch",
+    "3": "birch",
+}
+
+
+def normalize_species(sp: str) -> str:
+    """Normalize a species identifier to one of ``"spruce"``, ``"pine"``, ``"birch"``.
+
+    Accepts the same aliases as the R package, e.g. ``"gran"``/``"g"``/``"1"``
+    for spruce, ``"furu"``/``"f"``/``"2"`` for pine, and
+    ``"bjørk"``/``"bjork"``/``"lauv"``/``"3"`` for birch (case-insensitive).
+
+    Raises:
+        ValueError: If ``sp`` is not a recognized species or alias.
+    """
+    key = str(sp).strip().lower()
+    try:
+        return _SPECIES_ALIASES[key]
+    except KeyError as exc:
+        raise ValueError(
+            "sp must be one of spruce/pine/birch (or their aliases)"
+        ) from exc

--- a/python/taper_nor/inverse.py
+++ b/python/taper_nor/inverse.py
@@ -1,0 +1,100 @@
+"""Inverse taper functions: estimate height/dbh from diameters, and the
+height at which a given diameter occurs.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+from scipy import optimize
+
+from .coefficients import normalize_species
+from .taper import _taper
+
+
+def hfromd(d: Sequence[float], h: Sequence[float], sp: str = "spruce") -> dict[str, float]:
+    """Estimate total tree height and dbh from diameter measurements.
+
+    Fits ``h_top`` and ``dbh`` by minimizing the mean absolute error between
+    measured diameters ``d`` (at heights ``h``) and the taper curve.
+
+    Args:
+        d: Measured diameters (cm).
+        h: Heights above ground (m) corresponding to ``d``. Measurements
+            with ``h < 0.5`` are dropped, as the optimization is unstable
+            near ground level.
+        sp: Species, see :func:`taper_nor.coefficients.normalize_species`.
+
+    Returns:
+        A dict with keys ``"h_top"`` (estimated total height, m) and
+        ``"dbh"`` (estimated diameter at breast height, cm).
+
+    Raises:
+        ValueError: If all diameter measurements have ``h < 0.5``.
+    """
+    sp_n = normalize_species(sp)
+    d_arr = np.asarray(d, dtype=float)
+    h_arr = np.asarray(h, dtype=float)
+
+    mask = h_arr >= 0.5
+    d_arr, h_arr = d_arr[mask], h_arr[mask]
+    if len(d_arr) == 0:
+        raise ValueError("All diameter measurements have h < 0.5 m")
+
+    def objective(x: np.ndarray) -> float:
+        h_top, dbh = x
+        if h_top <= 0 or dbh <= 0:
+            return 1e6
+        try:
+            taper = _taper(h_arr, dbh, h_top, sp_n, True)
+        except Exception:
+            return 1e6
+        err = float(np.mean(np.abs(d_arr - taper)))
+        return err if np.isfinite(err) else 1e6
+
+    best = None
+    for st_h in np.arange(1.5, 46, 4):
+        for st_d in np.arange(10, 90, 10):
+            res = optimize.minimize(objective, x0=[st_h, st_d], method="Nelder-Mead")
+            if best is None or res.fun < best.fun:
+                best = res
+
+    return {"h_top": round(float(best.x[0]), 4), "dbh": round(float(best.x[1]), 4)}
+
+
+def dlocation(
+    dbh: float,
+    h_top: float,
+    d: Sequence[float],
+    sp: str = "spruce",
+    with_bark: bool = True,
+) -> list[float]:
+    """Estimate the height(s) at which given diameters occur along the stem.
+
+    Args:
+        dbh: Diameter at breast height, 1.3 m above ground (cm).
+        h_top: Total tree height (m).
+        d: Diameter(s) (cm) for which to find the corresponding height(s).
+        sp: Species, see :func:`taper_nor.coefficients.normalize_species`.
+        with_bark: Match against diameter over bark (``True``, default) or
+            under bark (``False``).
+
+    Returns:
+        Estimated height (m) for each element of ``d``.
+    """
+    sp_n = normalize_species(sp)
+
+    results = []
+    for d_o in d:
+
+        def objective(h_x: float, d_o: float = d_o) -> float:
+            if h_x < 0 or h_x > h_top:
+                return 1e6
+            d_i = _taper(np.array([h_x]), dbh, h_top, sp_n, with_bark)[0]
+            return float(abs(d_o - d_i))
+
+        res = optimize.minimize_scalar(objective, bounds=(0, h_top), method="bounded")
+        results.append(round(float(res.x), 2))
+
+    return results

--- a/python/taper_nor/inverse.py
+++ b/python/taper_nor/inverse.py
@@ -28,10 +28,20 @@ def hfromd(d: Sequence[float], h: Sequence[float], sp: str = "spruce") -> dict[s
 
     Returns:
         A dict with keys ``"h_top"`` (estimated total height, m) and
-        ``"dbh"`` (estimated diameter at breast height, cm).
+        ``"dbh"`` (estimated diameter at breast height, cm). Unrounded,
+        matching R's ``hfromd()``.
 
     Raises:
         ValueError: If all diameter measurements have ``h < 0.5``.
+
+    Note:
+        R's ``hfromd()`` defaults to a single optimization from a fixed
+        starting point (with fallbacks), only falling back to a 12x8 grid
+        search of starting points if that fails or ``grd_search=TRUE`` is
+        passed. This port always runs that 12x8 grid search (i.e. it
+        corresponds to R's ``grd_search=TRUE``), which is slower but more
+        robust. R's ``output=`` parameter ("h"/"d"/"all") is not exposed;
+        both estimates are always returned.
     """
     sp_n = normalize_species(sp)
     d_arr = np.asarray(d, dtype=float)
@@ -60,7 +70,7 @@ def hfromd(d: Sequence[float], h: Sequence[float], sp: str = "spruce") -> dict[s
             if best is None or res.fun < best.fun:
                 best = res
 
-    return {"h_top": round(float(best.x[0]), 4), "dbh": round(float(best.x[1]), 4)}
+    return {"h_top": float(best.x[0]), "dbh": float(best.x[1])}
 
 
 def dlocation(

--- a/python/taper_nor/taper.py
+++ b/python/taper_nor/taper.py
@@ -1,0 +1,80 @@
+"""Taper model for spruce, pine, and birch in Norway.
+
+Implements the variable-exponent taper equation of Hansen et al. (2023),
+based on Kozak's (1988) variable-exponent taper equation.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+from .bark import _bark
+from .coefficients import TAPER_COEFFICIENTS, normalize_species
+
+_R02 = math.sqrt(0.2)
+
+
+def _taper(
+    h: npt.ArrayLike, dbh: float, h_top: float, sp: str, with_bark: bool
+) -> np.ndarray:
+    """Diameter (cm) at height(s) ``h`` for a normalized species key."""
+    c = TAPER_COEFFICIENTS[sp]
+    h = np.asarray(h, dtype=float)
+
+    ratio = h / h_top
+    exponent = (
+        c["b4"] * ratio**2
+        + c["b5"] * np.log(ratio + 0.001)
+        + c["b6"] * np.sqrt(ratio)
+        + c["b7"] * np.exp(ratio)
+        + c["b8"] * (dbh / h_top)
+    )
+
+    # h > h_top makes the base of this term negative, which yields NaN for
+    # fractional exponents (e.g. during optimization in hfromd/dlocation).
+    with np.errstate(invalid="ignore", divide="ignore"):
+        d = (
+            c["b1"]
+            * dbh ** c["b2"]
+            * c["b3"] ** dbh
+            * ((1 - np.sqrt(ratio)) / (1 - _R02)) ** exponent
+        )
+
+    if with_bark:
+        return d
+
+    bark = _bark(d, h, dbh, h_top, sp)
+    d_ub = d - bark / 10
+    return np.where(d_ub < 0, 0, d_ub)
+
+
+def taper_nor(
+    h: Sequence[float] | npt.ArrayLike,
+    dbh: float,
+    h_top: float,
+    sp: str = "spruce",
+    with_bark: bool = True,
+) -> list[float]:
+    """Stem diameter(s) (cm) at given height(s) above ground.
+
+    Based on Hansen et al. (2023), a Kozak (1988) variable-exponent taper
+    equation.
+
+    Args:
+        h: Height(s) above ground (m) at which to return diameters.
+        dbh: Diameter at breast height, 1.3 m above ground, over bark (cm).
+        h_top: Total tree height (m).
+        sp: Species, see :func:`taper_nor.coefficients.normalize_species`.
+        with_bark: If ``True`` (default), return diameter over bark.
+            If ``False``, subtract bark thickness via :func:`taper_nor.bark.bark_nor`.
+
+    Returns:
+        Diameter (cm) for each element of ``h``.
+    """
+    sp_n = normalize_species(sp)
+    result = _taper(h, dbh, h_top, sp_n, with_bark)
+    return [round(float(x), 4) for x in np.atleast_1d(result)]

--- a/python/taper_nor/taper.py
+++ b/python/taper_nor/taper.py
@@ -73,8 +73,9 @@ def taper_nor(
             If ``False``, subtract bark thickness via :func:`taper_nor.bark.bark_nor`.
 
     Returns:
-        Diameter (cm) for each element of ``h``.
+        Diameter (cm) for each element of ``h``. Unrounded, matching R's
+        ``taperNOR()``.
     """
     sp_n = normalize_species(sp)
     result = _taper(h, dbh, h_top, sp_n, with_bark)
-    return [round(float(x), 4) for x in np.atleast_1d(result)]
+    return [float(x) for x in np.atleast_1d(result)]

--- a/python/taper_nor/volume.py
+++ b/python/taper_nor/volume.py
@@ -1,0 +1,68 @@
+"""Stem volume by integration of the taper curve."""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+import numpy as np
+from scipy import integrate
+
+from .coefficients import normalize_species
+from .taper import _taper
+
+
+def volume(
+    dbh: Sequence[float],
+    h_top: Sequence[float],
+    h_vol_lower: Sequence[float | None] | None = None,
+    h_vol_upper: Sequence[float | None] | None = None,
+    sp: str = "spruce",
+    with_bark: bool = True,
+) -> list[float]:
+    """Stem volume (m^3) by integrating the taper curve.
+
+    Args:
+        dbh: Diameter at breast height (cm), one entry per tree.
+        h_top: Total tree height (m), one entry per tree.
+        h_vol_lower: Lower integration height (m) per tree. Defaults to 1% of
+            ``h_top``. ``None`` entries fall back to this default.
+        h_vol_upper: Upper integration height (m) per tree. Defaults to
+            ``h_top``. ``None`` entries fall back to this default.
+        sp: Species, see :func:`taper_nor.coefficients.normalize_species`.
+        with_bark: Integrate diameter over bark (``True``, default) or under
+            bark (``False``).
+
+    Returns:
+        Stem volume (m^3) for each tree.
+
+    Raises:
+        ValueError: If ``dbh``, ``h_top``, ``h_vol_lower``, or ``h_vol_upper``
+            do not all have the same length.
+    """
+    n = len(dbh)
+    if len(h_top) != n:
+        raise ValueError("dbh and h_top must have the same length")
+
+    sp_n = normalize_species(sp)
+
+    lowers = h_vol_lower if h_vol_lower is not None else [None] * n
+    uppers = h_vol_upper if h_vol_upper is not None else [None] * n
+    if len(lowers) != n or len(uppers) != n:
+        raise ValueError("h_vol_lower and h_vol_upper must be the same length as dbh")
+
+    results = []
+    for d, ht, lo, up in zip(dbh, h_top, lowers, uppers):
+        upper = ht if up is None else up
+        lower = ht * 0.01 if lo is None else lo
+        if lower > upper:
+            lower = upper
+
+        def integrand(h: float, d: float = d, ht: float = ht) -> float:
+            taper = _taper(np.array([h]), d, ht, sp_n, with_bark)[0]
+            return ((taper / 100) / 2) ** 2
+
+        val, _ = integrate.quad(integrand, lower, upper)
+        results.append(round(math.pi * val, 6))
+
+    return results

--- a/python/taper_nor/volume.py
+++ b/python/taper_nor/volume.py
@@ -17,8 +17,8 @@ def volume(
     h_top: Sequence[float],
     h_vol_lower: Sequence[float | None] | None = None,
     h_vol_upper: Sequence[float | None] | None = None,
-    sp: str = "spruce",
-    with_bark: bool = True,
+    sp: str | Sequence[str] = "spruce",
+    with_bark: bool | Sequence[bool] = True,
 ) -> list[float]:
     """Stem volume (m^3) by integrating the taper curve.
 
@@ -30,39 +30,59 @@ def volume(
         h_vol_upper: Upper integration height (m) per tree. Defaults to
             ``h_top``. ``None`` entries fall back to this default.
         sp: Species, see :func:`taper_nor.coefficients.normalize_species`.
+            Either a single value applied to every tree, or one value per
+            tree (same length as ``dbh``).
         with_bark: Integrate diameter over bark (``True``, default) or under
-            bark (``False``).
+            bark (``False``). Either a single value applied to every tree, or
+            one value per tree (same length as ``dbh``).
 
     Returns:
-        Stem volume (m^3) for each tree.
+        Stem volume (m^3) for each tree. Unrounded, matching R's ``volume()``.
 
     Raises:
-        ValueError: If ``dbh``, ``h_top``, ``h_vol_lower``, or ``h_vol_upper``
-            do not all have the same length.
+        ValueError: If ``dbh``, ``h_top``, ``h_vol_lower``, ``h_vol_upper``,
+            ``sp``, or ``with_bark`` do not all have the same length (where
+            ``sp``/``with_bark`` may also be a single scalar applied to every
+            tree).
+
+    Note:
+        If ``h_vol_lower`` ends up greater than ``h_vol_upper`` for a given
+        tree, ``h_vol_lower`` is clamped to ``h_vol_upper`` for that tree
+        (yielding a volume of 0). This differs from the R implementation,
+        which has an inverted-condition bug in this edge case (it instead
+        clamps the *valid* trees to zero and leaves the actually-invalid
+        ones to integrate "backwards" into a negative volume).
     """
     n = len(dbh)
     if len(h_top) != n:
         raise ValueError("dbh and h_top must have the same length")
-
-    sp_n = normalize_species(sp)
 
     lowers = h_vol_lower if h_vol_lower is not None else [None] * n
     uppers = h_vol_upper if h_vol_upper is not None else [None] * n
     if len(lowers) != n or len(uppers) != n:
         raise ValueError("h_vol_lower and h_vol_upper must be the same length as dbh")
 
+    sps = [sp] * n if isinstance(sp, str) else list(sp)
+    if len(sps) != n:
+        raise ValueError("sp must be a single value or the same length as dbh")
+    sps_n = [normalize_species(s) for s in sps]
+
+    with_barks = [with_bark] * n if isinstance(with_bark, bool) else list(with_bark)
+    if len(with_barks) != n:
+        raise ValueError("with_bark must be a single value or the same length as dbh")
+
     results = []
-    for d, ht, lo, up in zip(dbh, h_top, lowers, uppers):
+    for d, ht, lo, up, sp_n, wb in zip(dbh, h_top, lowers, uppers, sps_n, with_barks):
         upper = ht if up is None else up
         lower = ht * 0.01 if lo is None else lo
         if lower > upper:
             lower = upper
 
-        def integrand(h: float, d: float = d, ht: float = ht) -> float:
-            taper = _taper(np.array([h]), d, ht, sp_n, with_bark)[0]
+        def integrand(h: float, d: float = d, ht: float = ht, sp_n: str = sp_n, wb: bool = wb) -> float:
+            taper = _taper(np.array([h]), d, ht, sp_n, wb)[0]
             return ((taper / 100) / 2) ** 2
 
         val, _ = integrate.quad(integrand, lower, upper)
-        results.append(round(math.pi * val, 6))
+        results.append(math.pi * val)
 
     return results

--- a/python/tests/test_taper_nor.py
+++ b/python/tests/test_taper_nor.py
@@ -65,6 +65,25 @@ def test_volume_length_mismatch_raises():
         volume(dbh=[30, 25], h_top=[25])
 
 
+def test_volume_per_tree_species_and_bark():
+    # Per-tree sp/with_bark should match calling volume() once per tree.
+    dbh, h_top = [30, 25], [25, 20]
+    sp, with_bark = ["spruce", "pine"], [True, False]
+
+    combined = volume(dbh=dbh, h_top=h_top, sp=sp, with_bark=with_bark)
+    individual = [
+        volume(dbh=[d], h_top=[ht], sp=[s], with_bark=[wb])[0]
+        for d, ht, s, wb in zip(dbh, h_top, sp, with_bark)
+    ]
+
+    assert combined == pytest.approx(individual)
+
+
+def test_volume_sp_length_mismatch_raises():
+    with pytest.raises(ValueError):
+        volume(dbh=[30, 25], h_top=[25, 20], sp=["spruce"])
+
+
 def test_dlocation_inverts_taper():
     dbh, h_top, sp = 30.0, 25.0, "spruce"
     target_d = [25.0, 15.0]

--- a/python/tests/test_taper_nor.py
+++ b/python/tests/test_taper_nor.py
@@ -1,0 +1,92 @@
+import math
+
+import pytest
+
+from taper_nor import bark_nor, dlocation, hfromd, normalize_species, taper_nor, volume
+
+
+def test_normalize_species_aliases():
+    assert normalize_species("spruce") == "spruce"
+    assert normalize_species("Gran") == "spruce"
+    assert normalize_species("1") == "spruce"
+    assert normalize_species("furu") == "pine"
+    assert normalize_species("bjork") == "birch"
+    assert normalize_species("bjørk") == "birch"
+
+
+def test_normalize_species_invalid():
+    with pytest.raises(ValueError):
+        normalize_species("oak")
+
+
+def test_taper_nor_known_value_spruce():
+    # Known output for spruce, dbh=30, h_top=25 at breast height (1.3 m).
+    result = taper_nor(h=1.3, dbh=30, h_top=25, sp="spruce")
+    assert result == pytest.approx([30.0913], abs=1e-4)
+
+
+def test_taper_nor_multiple_heights_decreasing():
+    result = taper_nor(h=[1, 5, 10, 20], dbh=30, h_top=25, sp="spruce")
+    assert len(result) == 4
+    # Diameter should decrease monotonically up the stem.
+    assert result == sorted(result, reverse=True)
+
+
+def test_taper_nor_under_bark_smaller_than_over_bark():
+    over = taper_nor(h=1, dbh=30, h_top=25, sp="spruce", with_bark=True)[0]
+    under = taper_nor(h=1, dbh=30, h_top=25, sp="spruce", with_bark=False)[0]
+    assert under < over
+
+
+def test_taper_nor_species_aliases_match():
+    assert taper_nor(h=1, dbh=30, h_top=25, sp="furu") == taper_nor(
+        h=1, dbh=30, h_top=25, sp="pine"
+    )
+
+
+def test_bark_nor_known_value_spruce():
+    result = bark_nor(d=25, h=1, dbh=30, h_top=25, sp="spruce")
+    assert result == pytest.approx([14.3571], abs=1e-4)
+
+
+def test_volume_known_value_spruce():
+    result = volume(dbh=[30], h_top=[25], sp="spruce")
+    assert result == pytest.approx([0.810026], abs=1e-5)
+
+
+def test_volume_under_bark_smaller():
+    over = volume(dbh=[30], h_top=[25], sp="spruce", with_bark=True)[0]
+    under = volume(dbh=[30], h_top=[25], sp="spruce", with_bark=False)[0]
+    assert under < over
+
+
+def test_volume_length_mismatch_raises():
+    with pytest.raises(ValueError):
+        volume(dbh=[30, 25], h_top=[25])
+
+
+def test_dlocation_inverts_taper():
+    dbh, h_top, sp = 30.0, 25.0, "spruce"
+    target_d = [25.0, 15.0]
+
+    heights = dlocation(dbh=dbh, h_top=h_top, d=target_d, sp=sp)
+    recovered_d = taper_nor(h=heights, dbh=dbh, h_top=h_top, sp=sp)
+
+    for expected, actual in zip(target_d, recovered_d):
+        assert actual == pytest.approx(expected, abs=0.01)
+
+
+def test_hfromd_recovers_known_tree():
+    dbh, h_top, sp = 30.0, 25.0, "spruce"
+    h = [1, 5, 10, 20]
+    d = taper_nor(h=h, dbh=dbh, h_top=h_top, sp=sp)
+
+    result = hfromd(d=d, h=h, sp=sp)
+
+    assert result["h_top"] == pytest.approx(h_top, abs=0.1)
+    assert result["dbh"] == pytest.approx(dbh, abs=0.1)
+
+
+def test_hfromd_raises_when_all_heights_too_low():
+    with pytest.raises(ValueError):
+        hfromd(d=[10, 12], h=[0.1, 0.4], sp="spruce")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(taperNOR)
+
+test_check("taperNOR")

--- a/tests/testthat/test-kublin_nor.R
+++ b/tests/testthat/test-kublin_nor.R
@@ -1,0 +1,42 @@
+test_that("kublin_nor returns a single height for a single Dx", {
+  Hx <- kublin_nor(Dx = 25, Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = 1)
+
+  expect_length(Hx, 1)
+  expect_type(Hx, "double")
+})
+
+test_that("kublin_nor returns one height per element for multi-element Dx", {
+  Dx <- c(25, 15)
+
+  Hx <- kublin_nor(Dx = Dx, Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = 1)
+
+  expect_length(Hx, length(Dx))
+  expect_type(Hx, "double")
+
+  # Looping manually over Dx should give the same result as passing the
+  # vector directly.
+  Hx_loop <- sapply(Dx, function(d) {
+    kublin_nor(Dx = d, Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = 1)
+  })
+
+  expect_equal(Hx, unname(Hx_loop))
+})
+
+test_that("kublin_nor still works for Hx input", {
+  Dx_vals <- kublin_nor(Hx = c(1.3, 5, 10), Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = 1)
+
+  expect_length(Dx_vals, 3)
+  expect_type(Dx_vals, "double")
+})
+
+test_that("kublin_nor errors when neither or both of Hx and Dx are given", {
+  expect_error(
+    kublin_nor(Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = 1),
+    "Either Hx or Dx must be given"
+  )
+
+  expect_error(
+    kublin_nor(Hx = 5, Dx = 25, Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = 1),
+    "Either Hx or Dx must be given"
+  )
+})


### PR DESCRIPTION
## Summary
- Fix `kublin_nor()` for multi-element `Dx`: `TapeR::E_HDx_HmDm_HT.f()` only root-finds a
  single height per call, so a `Dx` vector of length > 1 hit a `uniroot` error. Now
  loops over each `Dx` element and returns a vector of the same length; single-`Dx`
  behavior is unchanged. Adds a testthat suite covering single/multi `Dx`, `Hx` input,
  and error cases.
- Add a `python/` package (`taper-nor`) porting `taperNOR()`, `barkNOR()`, `volume()`,
  `hfromd()`, and `dlocation()` to Python (`kublin_nor()` stays R-only, since it
  depends on TapeR's mixed-effects model). Outputs match R's rounding behavior
  (unrounded, except `dlocation()` which rounds to 2 decimals like R), `volume()`
  supports per-tree `sp`/`with_bark` like R, and remaining intentional divergences
  from R are documented in `python/README.md`. Includes a pytest suite, and fixes a
  NaN-comparison bug in the ported `hfromd()` grid search.

Verified numerically against the R source (R 4.6.0): taper/bark/volume/dlocation
match R to 6-8 significant figures (dlocation matches exactly), and hfromd recovers
a known dbh=30/h_top=25 spruce tree to within ~1e-5.

## Test plan
- [ ] `R CMD check` / `devtools::test()` for the R package (not run in the dev environment - TapeR not installed)
- [x] `pytest` for `python/` - 15 passed
- [x] Manual numerical comparison of taper/bark/volume/dlocation/hfromd against R 4.6.0 source