### PR TITLE
Fix volume() input/clamping bugs and plot_taper() species label

### DIFF
--- a/R/plot_taper.R
+++ b/R/plot_taper.R
@@ -44,7 +44,7 @@ plot_taper<-function(dbh,h_top,sp="spruce",with_bark=TRUE){
     sp<-rep(sp,length(dbh))
   }
   if(length(with_bark)==1){
-    sp<-rep(with_bark,length(dbh))
+    with_bark<-rep(with_bark,length(dbh))
   }
 
   plotmat<-cbind(dbh,h_top,sp_num,1:length(dbh),with_bark)

--- a/R/volume.R
+++ b/R/volume.R
@@ -21,10 +21,10 @@
 volume<-function(dbh,h_top,h_vol_lower=NA,h_vol_upper=NA,sp="spruce",with_bark=TRUE){
 
   if(
-    class(dbh)!="numeric"|
-    class(h_top)!="numeric"|
-    (class(h_vol_lower)!="numeric" & !all(is.na(h_vol_lower)))|
-    (class(h_vol_upper)!="numeric" & !all(is.na(h_vol_upper)))
+    !is.numeric(dbh)|
+    !is.numeric(h_top)|
+    (!is.numeric(h_vol_lower) & !all(is.na(h_vol_lower)))|
+    (!is.numeric(h_vol_upper) & !all(is.na(h_vol_upper)))
   ){
     stop("dbh, h_top, h_vol_lower and h_vol_upper must be numeric.")
   }
@@ -49,7 +49,7 @@ volume<-function(dbh,h_top,h_vol_lower=NA,h_vol_upper=NA,sp="spruce",with_bark=T
 
 
   if(any(h_vol_lower>h_vol_upper)){
-    h_vol_lower[h_vol_lower<h_vol_upper]<-h_vol_upper[h_vol_lower<h_vol_upper]
+    h_vol_lower[h_vol_lower>h_vol_upper]<-h_vol_upper[h_vol_lower>h_vol_upper]
     warning("h_vol_lower must not be larger than h_vol_upper. h_vol_lower has been set to h_vol_upper.")
   }
 

--- a/tests/testthat/test-kublin_nor.R
+++ b/tests/testthat/test-kublin_nor.R
@@ -23,10 +23,13 @@ test_that("kublin_nor returns one height per element for multi-element Dx", {
 })
 
 test_that("kublin_nor still works for Hx input", {
-  Dx_vals <- kublin_nor(Hx = c(1.3, 5, 10), Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = 1)
+  # The Hx branch returns the full TapeR::E_DHx_HmDm_HT.f() list; the
+  # predicted diameters are in $DHx, one per element of Hx.
+  res <- kublin_nor(Hx = c(1.3, 5, 10), Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = 1)
 
-  expect_length(Dx_vals, 3)
-  expect_type(Dx_vals, "double")
+  expect_type(res, "list")
+  expect_length(res$DHx, 3)
+  expect_type(res$DHx, "double")
 })
 
 test_that("kublin_nor errors when neither or both of Hx and Dx are given", {

--- a/tests/testthat/test-plot_taper.R
+++ b/tests/testthat/test-plot_taper.R
@@ -1,0 +1,30 @@
+test_that("plot_taper runs without error for single, multi, and bark-vector cases", {
+  pdf(NULL)  # null graphics device
+  on.exit(dev.off(), add = TRUE)
+
+  expect_no_error(plot_taper(33, 30, sp = "spruce"))
+  expect_no_error(plot_taper(dbh = c(33, 20, 18), h_top = c(30, 25, 20), sp = c(1, 1, 3)))
+  expect_no_error(plot_taper(dbh = rep(25, 2), h_top = rep(27, 2), sp = 1,
+                             with_bark = c(TRUE, FALSE)))
+})
+
+test_that("plot_taper single-tree label keeps the species name", {
+  # Regression: with_bark recycling overwrote `sp`, so the label printed
+  # "species= TRUE" instead of the species name. The label is only observable
+  # via the mtext() call, so capture its first argument. The capture target
+  # lives in the global environment so trace()'s tracer (evaluated in the
+  # mtext call frame) can find it.
+  assign(".taper_test_label", NA_character_, envir = globalenv())
+  on.exit(suppressWarnings(rm(".taper_test_label", envir = globalenv())), add = TRUE)
+
+  trace(graphics::mtext,
+        tracer = quote(assign(".taper_test_label", text, envir = globalenv())),
+        print = FALSE)
+  on.exit(untrace(graphics::mtext), add = TRUE)
+
+  pdf(NULL)
+  on.exit(dev.off(), add = TRUE)
+  plot_taper(33, 30, sp = "spruce")
+
+  expect_match(get(".taper_test_label", envir = globalenv()), "species= spruce")
+})

--- a/tests/testthat/test-volume.R
+++ b/tests/testthat/test-volume.R
@@ -1,0 +1,34 @@
+test_that("volume accepts integer dbh and h_top", {
+  # Regression: previously class(dbh)!="numeric" rejected integers.
+  expect_equal(
+    volume(dbh = 20L, h_top = 30L, sp = "spruce"),
+    volume(dbh = 20, h_top = 30, sp = "spruce")
+  )
+})
+
+test_that("volume clamps only the trees where h_vol_lower > h_vol_upper", {
+  # Regression: the clamp condition was inverted, which zeroed the *valid*
+  # tree and produced a negative volume for the invalid one.
+  expect_warning(
+    res <- volume(
+      dbh = c(30, 30), h_top = c(25, 25),
+      h_vol_lower = c(2, 20), h_vol_upper = c(20, 2), sp = "spruce"
+    ),
+    "h_vol_lower must not be larger than h_vol_upper"
+  )
+
+  valid <- volume(dbh = 30, h_top = 25, h_vol_lower = 2, h_vol_upper = 20, sp = "spruce")
+
+  expect_equal(res[1], valid)  # valid tree untouched
+  expect_equal(res[2], 0)      # invalid tree clamped to a zero-width interval
+  expect_true(all(res >= 0))   # never negative
+})
+
+test_that("volume default single- and multi-tree results are unchanged", {
+  expect_equal(volume(30, 25, sp = "spruce"), 0.8100256, tolerance = 1e-6)
+  expect_equal(
+    volume(dbh = c(20, 25, 30), h_top = c(30, 25, 37)),
+    c(0.4861970, 0.5913435, 1.2419804),
+    tolerance = 1e-6
+  )
+})


### PR DESCRIPTION
## Summary

Three small, self-contained bug fixes (each with a regression test), found while reviewing the package.

### `volume()` — rejects integer input
Validation used `class(dbh) != "numeric"`, so integer-typed columns (common when reading from a data frame) were rejected:
```r
volume(dbh = 20L, h_top = 30L)   # before: ERROR "... must be numeric."
```
Switched to `is.numeric()` for all four numeric args (also robust against the length-2 `class()` of matrices in R 4.x).

### `volume()` — inverted `h_vol_lower`/`h_vol_upper` clamp
The clamp condition was inverted:
```r
h_vol_lower[h_vol_lower < h_vol_upper] <- h_vol_upper[h_vol_lower < h_vol_upper]
```
When any tree had `lower > upper`, this rewrote the **valid** trees and left the invalid ones untouched. Demonstrated:
```r
volume(dbh = c(30,30), h_top = c(25,25),
       h_vol_lower = c(2,20), h_vol_upper = c(20,2))
# before:  0  -0.6563628   (valid tree zeroed; invalid tree negative)
# after:   0.6563628  0    (valid tree kept; invalid tree clamped to 0)
```

### `plot_taper()` — `with_bark` recycling overwrote `sp`
```r
if(length(with_bark)==1){ sp <- rep(with_bark, length(dbh)) }   # assigns to sp
```
On the default `with_bark = TRUE`, this clobbered `sp`, so the single-tree title printed `species= TRUE` instead of the species name (and `with_bark` was never actually recycled). Fixed to assign to `with_bark`.

## Test plan
- [x] `testthat` suite run against the installed package (R 4.6.0, TapeR + testthat installed): **kublin_nor 10, plot_taper 4, volume 7 — all pass**
- New regression tests: `test-volume.R` (integer input, per-element clamp, unchanged defaults) and `test-plot_taper.R` (smoke tests + species-label check)
- Also corrected the `kublin_nor` Hx-input test from PR #8 (it asserted a bare numeric; the Hx branch returns the full `TapeR::E_DHx_HmDm_HT.f()` list, with diameters in `$DHx`) — this test had never been executed because TapeR wasn't installed in that environment.

Out of scope (noted for a follow-up): `kublin_nor()`'s species dispatch assigns the spruce `par.lme` for all of `sp = 1/2/3`, so pine and birch silently use the spruce model — fixing that needs the actual pine/birch model objects.