### PR TITLE
kublin_nor(): error for pine/birch instead of silently using the spruce model

### DIFF
--- a/R/kublin_no.R
+++ b/R/kublin_no.R
@@ -10,7 +10,11 @@
 #' @param Hm height above ground of measured diameters (m)
 #' @param Dm measured diameters (cm)
 #' @param mHt measured tree height (m) above ground
-#' @param sp species
+#' @param sp species. \strong{Only spruce is currently supported}
+#'   ("spruce", "s", "gran", "g", "1"); the Kublin (TapeR) mixed-effects model
+#'   has only been fitted for spruce in this package. Pine and birch raise an
+#'   error - use \code{\link{taperNOR}} for those species, or supply a fitted
+#'   \code{par.lme}.
 #' @param ... parameters handed over to E_DHx_HmDm_HT.f or E_HDx_HmDm_HT.f
 #' @return When Hx is given: diameters at Hx (cm). When Dx is given: heights where d=Dx (m).
 #'   \code{TapeR::E_HDx_HmDm_HT.f()} only root-finds a single height per call, so when
@@ -20,12 +24,14 @@
 
 kublin_nor <- function(Hx=NULL,Hm,Dm,mHt,sp=1,Dx=NULL,...) {
 
-  if(sp==1){
+  sp_norm<-tolower(as.character(sp))
+  if(sp_norm%in%c("spruce","s","gran","g","1")){
     par_lme<-kublin_par_lme_spruce
-  } else if(sp==2){
-    par_lme<-kublin_par_lme_spruce
-  } else if(sp==3){
-    par_lme<-kublin_par_lme_spruce
+  } else if(sp_norm%in%c("pine","p","furu","f","2",
+                         "birch","b","bj\u00f8rk","bjork","bj","lauv","l","3")){
+    stop("kublin_nor() currently only supports spruce. The Kublin (TapeR) model has not been fitted for pine or birch in this package; use taperNOR() for those species, or supply a fitted par.lme.")
+  } else {
+    stop("sp must indicate spruce, the only species currently supported by kublin_nor().")
   }
   if(is.null(Hx)&!is.null(Dx)){
     if(length(Dx)>1){

--- a/man/kublin_nor.Rd
+++ b/man/kublin_nor.Rd
@@ -15,7 +15,11 @@ kublin_nor(Hx = NULL, Hm, Dm, mHt, sp = 1, Dx = NULL, ...)
 
 \item{mHt}{measured tree height (m) above ground}
 
-\item{sp}{species}
+\item{sp}{species. \strong{Only spruce is currently supported}
+("spruce", "s", "gran", "g", "1"); the Kublin (TapeR) mixed-effects model
+has only been fitted for spruce in this package. Pine and birch raise an
+error - use \code{\link{taperNOR}} for those species, or supply a fitted
+\code{par.lme}.}
 
 \item{Dx}{or diameters (cm) for which to return a height}
 

--- a/tests/testthat/test-kublin_nor.R
+++ b/tests/testthat/test-kublin_nor.R
@@ -43,3 +43,36 @@ test_that("kublin_nor errors when neither or both of Hx and Dx are given", {
     "Either Hx or Dx must be given"
   )
 })
+
+test_that("kublin_nor accepts spruce via its aliases", {
+  # Numeric 1 and the string aliases should all resolve to the spruce model.
+  ref <- kublin_nor(Dx = 25, Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = 1)
+
+  for (alias in c("spruce", "s", "gran", "g", "1")) {
+    expect_equal(
+      kublin_nor(Dx = 25, Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = alias),
+      ref
+    )
+  }
+})
+
+test_that("kublin_nor errors for pine and birch (only spruce is fitted)", {
+  # Regression: pine/birch previously fell through to the spruce model
+  # silently. They must now error rather than return spruce-based results.
+  # "bjork" (ASCII) covers the birch path; the non-ASCII Norwegian alias is
+  # exercised by the function but kept out of this test to keep the source ASCII.
+  for (alias in c("pine", "p", "furu", "f", "2",
+                  "birch", "b", "bjork", "bj", "lauv", "l", "3")) {
+    expect_error(
+      kublin_nor(Dx = 25, Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = alias),
+      "only supports spruce"
+    )
+  }
+})
+
+test_that("kublin_nor errors for an unrecognized species", {
+  expect_error(
+    kublin_nor(Dx = 25, Hm = c(1.3, 5), Dm = c(30, 22), mHt = 25, sp = "oak"),
+    "sp must indicate spruce"
+  )
+})


### PR DESCRIPTION
## Summary

`kublin_nor()`'s species dispatch assigned the spruce `par.lme` for **all** of `sp = 1/2/3`:
```r
if(sp==1){ par_lme<-kublin_par_lme_spruce }
else if(sp==2){ par_lme<-kublin_par_lme_spruce }   # pine -> spruce
else if(sp==3){ par_lme<-kublin_par_lme_spruce }   # birch -> spruce
```
So pine and birch **silently returned spruce-based results**, and there was no `else`, so any other `sp` left `par_lme` undefined and failed with a cryptic downstream error.

### Why not just wire up pine/birch?
Only the spruce Kublin model exists. `kublin_par_lme_spruce` is the **only** object in `sysdata.rda`, and it's the only one in the repo's git history. The Kublin (K13) mixed-effects B-spline model was just one of 11 taper equations *compared* in Hansen et al. (2023); the model the paper **selected and published** is the Kozak variable-exponent equation — those are the `b1`–`b8` coefficients already in `taperNOR()` for all three species. A TapeR `par.lme` (knots, spline coefficients, random-effects covariances) isn't published in the paper for any species; the spruce one was fitted separately. Supporting pine/birch would require re-fitting `TapeR::TapeR_FIT_LME.f` on the NIBIO training data — out of scope here.

### This PR
Normalize `sp` to the same aliases the rest of the package uses, then:
- **spruce** (`"spruce"`/`"s"`/`"gran"`/`"g"`/`"1"`) → spruce model, as before;
- **pine / birch** → clear error pointing to `taperNOR()`;
- **anything else** → distinct "unsupported species" error.

Side benefit: `sp = "spruce"` (and the other string aliases) now work — previously only the numeric `sp = 1` did, since the old code used `sp==1`.

## Test plan
- [x] `testthat` against the installed package (R 4.6.0, TapeR + testthat): **kublin_nor / plot_taper / volume — all pass**
- New tests: spruce aliases all resolve to the spruce model; `pine`/`furu`/`2`/`birch`/`bjork`/`lauv`/`3` (and aliases) all error with "only supports spruce"; unrecognized `sp` errors distinctly.
- Verified directly: `sp=1` and `sp="spruce"` both return `2.985736`; `sp=2`/`"birch"` error; `sp="oak"` errors.