### PR TITLE
Package hygiene: metadata, CITATION, CI workflows, R CMD check fixes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,8 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE\.md$
+^python$
+^\.github$
+^\.git$
+^\.gitignore$
+^.*\.orig$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Runs R CMD check across the major platforms on push / pull request.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: macos-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,40 @@
+# Runs the Python package test suite (python/taper_nor) with pytest.
+on:
+  push:
+    branches: [main, master]
+    paths: ['python/**', '.github/workflows/pytest.yaml']
+  pull_request:
+    branches: [main, master]
+    paths: ['python/**', '.github/workflows/pytest.yaml']
+
+name: pytest.yaml
+
+permissions: read-all
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    name: python ${{ matrix.python-version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.11', '3.13']
+
+    defaults:
+      run:
+        working-directory: python
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with test dependencies
+        run: pip install ".[test]"
+
+      - name: Run pytest
+        run: pytest -q

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,22 @@
 Package: taperNOR
 Type: Package
-Title: What the Package Does (Title Case)
+Title: Taper, Volume and Bark Thickness Models for Spruce, Pine and Birch in Norway
 Version: 0.1.0
-Author: Johannes Rahlf, Endre Hofstad Hansen
-Maintainer: Johannes Rahlf <johannes.rahlf@nibio.no>
-Description: Taper models for Norway
-    for the main tree species spruce, pine and birch.
+Authors@R: c(
+    person("Johannes", "Rahlf", email = "johannes.rahlf@nibio.no", role = c("aut", "cre")),
+    person(c("Endre", "Hofstad"), "Hansen", role = "aut"))
+Description: Stem taper, bark thickness, and volume models for the main
+    Norwegian tree species (Norway spruce, Scots pine, and birch), based on
+    Hansen et al. (2023) <doi:10.1080/02827581.2023.2243821> and the
+    correction <doi:10.1080/02827581.2024.2358467>. Provides functions to
+    predict stem diameter along the bole, bark thickness, and stem volume by
+    numerical integration of the taper curve, and to invert these
+    relationships (e.g. estimating height and diameter at breast height from
+    measured diameters).
 License: MIT + file LICENSE
+URL: https://github.com/SmartForest-no/taperNOR
+BugReports: https://github.com/SmartForest-no/taperNOR/issues
 Encoding: UTF-8
-LazyData: true
 Imports:
     TapeR
 RoxygenNote: 7.3.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2022
-COPYRIGHT HOLDER: taperNO authors
+COPYRIGHT HOLDER: taperNOR authors

--- a/R/hfromd.R
+++ b/R/hfromd.R
@@ -26,7 +26,7 @@ hfromd<-function(d,h,sp="spruce",output="h",grd_search=F){
   result<-try(.hfromd_optim(st,h,d,sp),T)
 
 
-  if(class(result)=="try-error"){
+  if(inherits(result,"try-error")){
     st<-
       c(
         stats::predict(stats::lm(d~h),newdata = data.frame(h=1.3)),
@@ -35,7 +35,7 @@ hfromd<-function(d,h,sp="spruce",output="h",grd_search=F){
     result<-try(.hfromd_optim(st,h,d,sp),T)
   }
 
-  if(class(result)=="try-error"|grd_search){
+  if(inherits(result,"try-error")|grd_search){
     st_df<-expand.grid(st_h=seq(1.5,45.5,4),st_d=seq(10,80,10))
     st_df$optim<-apply( st_df,1,function(x){try(.hfromd_optim(x,h,d,sp)$value,silent = T)})
     st_df$optim[!grepl("\\d",st_df$optim)]<-NA
@@ -43,7 +43,7 @@ hfromd<-function(d,h,sp="spruce",output="h",grd_search=F){
     result<-try(.hfromd_optim(st_df[which.min(st_df$optim),1:2],h,d,sp))
   }
 
-  if(class(result)=="try-error") return(.hfromd_optim(st,h,d,sp))
+  if(inherits(result,"try-error")) return(.hfromd_optim(st,h,d,sp))
 
   names(result$par)<-c("h","d")
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,31 @@
+citHeader(
+  "To cite taperNOR in publications, please cite the underlying models:"
+)
+
+bibentry(
+  bibtype  = "Article",
+  title    = "Taper, volume, and bark thickness models for spruce, pine, and birch in Norway",
+  author   = c(
+    person("Endre", "Hansen"),
+    person("Johannes", "Rahlf"),
+    person("Rasmus", "Astrup"),
+    person("Terje", "Gobakken")
+  ),
+  journal  = "Scandinavian Journal of Forest Research",
+  year     = "2023",
+  doi      = "10.1080/02827581.2023.2243821"
+)
+
+bibentry(
+  bibtype  = "Article",
+  title    = "Correction to: Taper, volume, and bark thickness models for spruce, pine, and birch in Norway",
+  author   = c(
+    person("Endre", "Hansen"),
+    person("Johannes", "Rahlf"),
+    person("Rasmus", "Astrup"),
+    person("Terje", "Gobakken")
+  ),
+  journal  = "Scandinavian Journal of Forest Research",
+  year     = "2024",
+  doi      = "10.1080/02827581.2024.2358467"
+)


### PR DESCRIPTION
## Summary

Package-hygiene pass — no change to model behaviour. Brings `R CMD check --as-cran` from 3 NOTEs down to 2 (the two remaining are the benign "New submission" and a local-only "pandoc not installed" note that disappears on CI).

### DESCRIPTION
- Replace the placeholder `Title: What the Package Does (Title Case)` with a real title.
- Convert `Author`/`Maintainer` to `Authors@R` (clears the CRAN-incoming NOTE).
- Add `URL` and `BugReports`.
- Expand `Description` and cite the paper + correction DOIs.
- Drop `LazyData: true` (no-op here — coefficients live in internal `R/sysdata.rda`; the build already omitted it).

### Code
- `hfromd.R`: use `inherits(result, "try-error")` instead of `class(result) == "try-error"` (clears the "comparing class() to string" NOTE; robust against R 4.x's length-2 `class()`).

### Packaging / docs
- Add `inst/CITATION` (2023 paper + 2024 correction) so `citation("taperNOR")` works — verified it renders both entries.
- Add CI: `.github/workflows/R-CMD-check.yaml` (linux/macOS/windows, r-lib/actions) and `.github/workflows/pytest.yaml` (runs the `python/` suite on 3.9/3.11/3.13).
- `.Rbuildignore`: exclude `python/`, `.github/`, `.git/`, `.gitignore` so they aren't bundled into the R source tarball (the `python/` dir would otherwise trigger a top-level-files NOTE).
- Fix the LICENSE stub typo: `taperNO authors` → `taperNOR authors`.

### Note on the GitHub license badge
GitHub currently shows the repo license as **"Other"**. This is because GitHub's `licensee` keys on the bare `LICENSE` file, which — per the R/CRAN `MIT + file LICENSE` convention — is a 2-line stub (`YEAR:` / `COPYRIGHT HOLDER:`) that `licensee` can't match to MIT, even though `LICENSE.md` is full MIT. Making GitHub display "MIT" would require putting the full licence text in `LICENSE`, which costs 1–2 `R CMD check` NOTEs. I kept the CRAN-clean stub instead (verified: 0 license NOTEs). The package is unambiguously MIT-licensed via `DESCRIPTION` + `LICENSE.md`.

## Test plan
- [x] `R CMD check --as-cran` (R 4.6.0): **OK, 2 NOTEs** (New submission; pandoc-not-installed — both benign)
- [x] testthat suite passes under the check (no test ERRORs)
- [x] `citation("taperNOR")` renders both references
- [ ] CI workflows will run on this PR once merged-eligible (first run validates them)